### PR TITLE
Allow highlighter to modify HTML based on item properties

### DIFF
--- a/bootstrap3-typeahead.js
+++ b/bootstrap3-typeahead.js
@@ -237,7 +237,7 @@
       items = $(items).map(function (i, item) {
         var text = self.displayText(item);
         i = $(that.options.item).data('value', item);
-        i.find('a').html(that.highlighter(text));
+        i.find('a').html(that.highlighter(text, item));
         if (text == self.$element.val()) {
             i.addClass('active');
             self.$element.data('active', item);


### PR DESCRIPTION
Currently only able to modify the resulting rendered HTML based on the text returned from the displayText function. 
Currently we have item as a JS object, containing meta-data about the item (like what type of search result it was). 
We need to modify the output HTML based on the meta data of the item (insert icons/images/differently styled text, etc.), which is unavailable when calling the highlighter method. 
This change allows the highlighter to have access to the item and do whatever it needs to based on the metadata, as well as the parsed display text.
